### PR TITLE
Added CastAction.cs and relating scripts.

### DIFF
--- a/CastAction.cs
+++ b/CastAction.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SA
+{
+    public abstract class CastAction : ScriptableObject
+    {
+
+        public abstract void Execute(StateManager states);
+        //New action i implement to handle Raycast Data. Instead of creating raycasts with the same direction but different distances, we will use these actions to recycle raycasts amoungt different actions.
+
+    }
+}

--- a/IsGrounded.cs
+++ b/IsGrounded.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SA
+{
+    [CreateAssetMenu(menuName = "Actions/State Actions/IsGrounded")]
+    public class IsGrounded : StateActions
+    {
+        public TierOneRaycast raycast;
+
+        public override void Execute(StateManager states)
+        {
+            raycast.originOffset = Vector3.up * 0.7f;
+            raycast.origin += raycast.originOffset;
+            raycast.Execute(states);
+
+            if(raycast.Hit)       
+                states.isGrounded = true;
+            
+            else
+                states.isGrounded = false;
+            
+
+            states.anim.SetBool(states.hashes.IsGrounded, states.isGrounded);
+        }
+
+    }
+}
+
+

--- a/RaycastData.cs
+++ b/RaycastData.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SA
+{
+    public enum NamedVectorDirection { Forwards, Backwards, Upwards, Downwards, Right, Left, Zero}//Zero Added for overriding
+                                           //pitch,yaw
+    public enum PreciseVectorDirection { NotApplied,Acute_Lateral, Obtuse_Lateral,
+                                                      Acute_Upwards, Obtuse_Upwards,
+                                                        Acute_Downwards, Obtuse_Downwards}
+
+    [System.Serializable]
+    public class RaycastData
+    {
+
+        public Vector3 hitNormal;
+        public Vector3 hitPoint;
+        public Collider hitCollider;
+
+
+        public bool Cleared { get; private set; }
+
+        public void SetData(Vector3 point, Vector3 normal)
+        { 
+            hitNormal = normal;
+            hitPoint = point;
+
+
+
+            Cleared = false;
+        }
+
+        public void SetCollider(Collider target)
+        {
+
+            hitCollider = target;
+
+        }
+        public void ClearData()
+        {
+            hitNormal = Vector3.zero;
+            hitPoint = Vector3.zero;
+
+            Cleared = true;
+        }
+    }
+}

--- a/TierOneRaycast.cs
+++ b/TierOneRaycast.cs
@@ -40,12 +40,12 @@ namespace SA {
             if (origin != (states.mTransform.position + originOffset) && !IsSlave)
                 origin = states.mTransform.position + originOffset;
 
-            Hit = isHit(states.masterHitData);
+            Hit = isHit();
 
             if (!Hit && !hitData.Cleared)
             {
                 hitData.ClearData();
-                states.interactionData.ClearData();
+                
                 return;
             }
 
@@ -58,7 +58,7 @@ namespace SA {
             
         }
 
-        public bool isHit(EasyCastMasterData masterHitGather)
+        public bool isHit()
         {
             
             RaycastHit hit;

--- a/TierOneRaycast.cs
+++ b/TierOneRaycast.cs
@@ -1,0 +1,149 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace SA {
+    [CreateAssetMenu(menuName = "CastAction/T1 Cast")]
+    public class TierOneRaycast : CastAction {
+
+        [Header("RaySpawning")]
+        public float RayDistance = 1;
+
+        public NamedVectorDirection direction;
+        public PreciseVectorDirection preciseDirection;
+
+        public bool isTriggerQuery = false;
+        public LayerMask hitLayers;
+
+
+        public Vector3 Direction { get; set; }
+        public Vector3 originOffset { get; set; }
+        public Vector3 origin { get; set; }
+
+        public RaycastData hitData { get; private set; }
+
+        [Header("Debug")]
+        public bool DebugDraw = true;
+        public Color DrawColor;
+
+        public bool Hit { get; private set; }
+        public bool IsSlave { get; set; }
+
+
+        public override void Execute(StateManager states)
+        {
+            Direction = m_Direction(direction,preciseDirection,states.mTransform);
+
+            if (Direction == Vector3.zero)
+                return;
+
+            if (origin != (states.mTransform.position + originOffset) && !IsSlave)
+                origin = states.mTransform.position + originOffset;
+
+            Hit = isHit(states.masterHitData);
+
+            if (!Hit && !hitData.Cleared)
+            {
+                hitData.ClearData();
+                states.interactionData.ClearData();
+                return;
+            }
+
+
+            if (!DebugDraw)
+                return;
+
+            Debug.DrawRay(origin, Direction * RayDistance, DrawColor);
+
+            
+        }
+
+        public bool isHit(EasyCastMasterData masterHitGather)
+        {
+            
+            RaycastHit hit;
+
+            if(Physics.Raycast(origin, Direction, out hit, RayDistance, hitLayers, isTriggerQuery ? QueryTriggerInteraction.Collide:QueryTriggerInteraction.Ignore))
+            {
+                hitData.SetData(hit.point, hit.normal);
+
+                if (hit.collider)
+                {
+                    hitData.SetCollider(hit.collider);
+                }
+
+             
+                return true;
+            }
+            else
+            {
+
+                
+            }
+
+
+            return false;
+
+
+        }
+
+        Vector3 m_Direction(NamedVectorDirection nD, PreciseVectorDirection pD, Transform casterTransform)
+        {
+            Vector3 result = Vector3.zero;
+
+            switch (nD)
+            {
+                case NamedVectorDirection.Forwards:
+                    result = casterTransform.forward;
+                    break;
+                case NamedVectorDirection.Backwards:
+                    result = -casterTransform.forward;
+                    break;
+                case NamedVectorDirection.Upwards:
+                    result = casterTransform.up;
+                    break;
+                case NamedVectorDirection.Downwards:
+                    result = -casterTransform.up;
+                    break;
+                case NamedVectorDirection.Right:
+                    result = casterTransform.right;
+                    break;
+                case NamedVectorDirection.Left:
+                    result = -casterTransform.right;
+                    break;
+                default:
+                    break;
+            }
+
+            if (pD == PreciseVectorDirection.NotApplied)
+                return result;
+
+            switch (pD)
+            {            
+                case PreciseVectorDirection.Acute_Lateral:
+                    result += new Vector3( .5f, 0, 0);
+                    break;
+                case PreciseVectorDirection.Obtuse_Lateral:
+                    result += new Vector3( -.5f, 0, 0);
+                    break;
+                case PreciseVectorDirection.Acute_Upwards:
+                    result += new Vector3( .5f, .5f, 0);
+                    break;
+                case PreciseVectorDirection.Obtuse_Upwards:
+                    result += new Vector3( -.5f, .5f, 0);
+                    break;
+                case PreciseVectorDirection.Acute_Downwards:
+                    result += new Vector3( .5f, -.5f, 0);
+                    break;
+                case PreciseVectorDirection.Obtuse_Downwards:
+                    result += new Vector3( -.5f, -.5f, 0);
+                    break;
+                default:
+                    break;
+            }
+
+            return result;
+
+        }
+    }
+}


### PR DESCRIPTION
"TierOne" is referring to the amount of steps the raycast takes. For example, while vaulting we use a raycast forward and downwards to confirm our actions affirmation. This would be a "TierTwoRaycast" once this has been scripted.

The is grounded script has been provided as an example, replacing the raycast function within this script with a cast action variable.
Cast Actions are made the same way as other variables, through the asset creation menu. You will then be able to choose the direction and length of the raycast from within the castaction asset.

This system is made to remove having to script out raycasts, during tutorials with SharpAccent. But it can be used wherever you find a place for it.